### PR TITLE
Authorizations list in Access code view.

### DIFF
--- a/app/models/decidim/access_codes/access_code.rb
+++ b/app/models/decidim/access_codes/access_code.rb
@@ -34,7 +34,11 @@ module Decidim
       end
 
       def authorizations
-        Decidim::Authorization.where(name: "access_codes").where("metadata->>'access_code_id' = '?'", id)
+        auths = []
+        Decidim::Authorization.find_each do |auth|
+          auths << auth if auth.metadata["access_code_id"] == id
+        end
+        auths
       end
 
       private

--- a/app/models/decidim/access_codes/access_code.rb
+++ b/app/models/decidim/access_codes/access_code.rb
@@ -34,11 +34,7 @@ module Decidim
       end
 
       def authorizations
-        auths = []
-        Decidim::Authorization.find_each do |auth|
-          auths << auth if auth.metadata["access_code_id"] == id
-        end
-        auths
+        Decidim::Authorization.select { |auth| auth.metadata["access_code_id"] == id }
       end
 
       private


### PR DESCRIPTION
Show view of an access code now shows the list of authorizations.
The metadata's values were encrypted, and the query didn't find the relation.